### PR TITLE
Removing VOLUME line from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,4 @@ USER smartling
 COPY start-connector.sh start-connector.sh
 COPY stop-connector.sh stop-connector.sh
 COPY repo-connector-template.conf repo-connector-template.conf
-VOLUME /opt/repo-connector/cfg/repository-data
 ENTRYPOINT ["./start-connector.sh"]


### PR DESCRIPTION
I'm hitting permissions issues when running this without mounting an
external volume into the container