### PR TITLE
Change to start-connector.sh script to do proper signal handling

### DIFF
--- a/start-connector.sh
+++ b/start-connector.sh
@@ -9,4 +9,11 @@ JAVA_XMX=${JAVA_XMX:-3584M}
 
 trap "/opt/repo-connector/stop-connector.sh" HUP INT QUIT TERM
 
-java -Xms${JAVA_XMS} -Xmx${JAVA_XMX} -jar /opt/repo-connector/${CONNECTOR_JAR_PREFIX}.jar -start
+java -Xms${JAVA_XMS} -Xmx${JAVA_XMX} -jar /opt/repo-connector/${CONNECTOR_JAR_PREFIX}.jar -start &
+
+pid="${!}"
+
+# Wait forever, but allow handling signals...
+while true; do
+    tail -f /dev/null & wait ${!}
+done

--- a/start-connector.sh
+++ b/start-connector.sh
@@ -7,4 +7,6 @@ envsubst < repo-connector-template.conf > cfg/repo-connector.conf
 JAVA_XMS=${JAVA_XMS:-1024M}
 JAVA_XMX=${JAVA_XMX:-3584M}
 
+trap "/opt/repo-connector/stop-connector.sh" HUP INT QUIT TERM
+
 java -Xms${JAVA_XMS} -Xmx${JAVA_XMX} -jar /opt/repo-connector/${CONNECTOR_JAR_PREFIX}.jar -start

--- a/start-connector.sh
+++ b/start-connector.sh
@@ -17,15 +17,14 @@ JAVA_XMX=${JAVA_XMX:-3584M}
 sig_handler()
 {
     if [ ${pid} -ne 0  ]; then
-        kill -SIGTERM "${pid}"
+        /opt/repo-connector/stop-connector.sh
         wait "${pid}"
+        exit 143; # 128 + 15 -- SIGTERM
     fi
-    exit 143; # 128 + 15 -- SIGTERM
 }
 
 # Setup handlers
-# On callback, kill the last background process, which is `tail -f /dev/null` and execute the specified handler
-trap "kill ${!}; /opt/repo-connector/stop-connector.sh" HUP INT QUIT TERM
+trap "sig_handler" HUP INT QUIT TERM
 
 java -Xms${JAVA_XMS} -Xmx${JAVA_XMX} -jar /opt/repo-connector/${CONNECTOR_JAR_PREFIX}.jar -start &
 
@@ -33,5 +32,5 @@ pid="${!}"
 
 # Wait forever, but allow handling signals...
 while true; do
-    tail -f /dev/null & wait "${!}"
+    wait "${pid}"
 done

--- a/start-connector.sh
+++ b/start-connector.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Debugging...
-set -x
+#set -x
 
 pid=0
 

--- a/start-connector.sh
+++ b/start-connector.sh
@@ -15,5 +15,5 @@ pid="${!}"
 
 # Wait forever, but allow handling signals...
 while true; do
-    tail -f /dev/null & wait ${!}
+    tail -f /dev/null & wait ${pid}
 done

--- a/start-connector.sh
+++ b/start-connector.sh
@@ -3,6 +3,8 @@
 # Debugging...
 set -x
 
+pid=0
+
 # Replace environment variables in the configuration file first. Since this
 # is done at runtime by the container it won't be persisted.
 envsubst < repo-connector-template.conf > cfg/repo-connector.conf

--- a/start-connector.sh
+++ b/start-connector.sh
@@ -10,7 +10,20 @@ envsubst < repo-connector-template.conf > cfg/repo-connector.conf
 JAVA_XMS=${JAVA_XMS:-1024M}
 JAVA_XMX=${JAVA_XMX:-3584M}
 
-trap "/opt/repo-connector/stop-connector.sh" HUP INT QUIT TERM
+# This signal handling is based on this blog post:
+# https://medium.com/@gchudnov/trapping-signals-in-docker-containers-7a57fdda7d86
+sig_handler()
+{
+    if [ ${pid} -ne 0  ]; then
+        kill -SIGTERM "${pid}"
+        wait "${pid}"
+    fi
+    exit 143; # 128 + 15 -- SIGTERM
+}
+
+# Setup handlers
+# On callback, kill the last background process, which is `tail -f /dev/null` and execute the specified handler
+trap "kill ${!}; /opt/repo-connector/stop-connector.sh" HUP INT QUIT TERM
 
 java -Xms${JAVA_XMS} -Xmx${JAVA_XMX} -jar /opt/repo-connector/${CONNECTOR_JAR_PREFIX}.jar -start &
 
@@ -18,7 +31,5 @@ pid="${!}"
 
 # Wait forever, but allow handling signals...
 while true; do
-    tail -f /dev/null & wait ${!}
+    tail -f /dev/null & wait "${!}"
 done
-
-wait ${pid}

--- a/start-connector.sh
+++ b/start-connector.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Debugging...
+set -x
+
 # Replace environment variables in the configuration file first. Since this
 # is done at runtime by the container it won't be persisted.
 envsubst < repo-connector-template.conf > cfg/repo-connector.conf
@@ -15,5 +18,7 @@ pid="${!}"
 
 # Wait forever, but allow handling signals...
 while true; do
-    tail -f /dev/null & wait ${pid}
+    tail -f /dev/null & wait ${!}
 done
+
+wait ${pid}


### PR DESCRIPTION
@tfhartmann,

Check this out when you have a chance. This should make the connector stop a lot faster and actually properly shut it down.